### PR TITLE
Adds support for more Distros

### DIFF
--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -119,11 +119,11 @@ function GetDefaultRepos {
   fi
 
   case $( rpm -qf /etc/os-release --qf '%{name}' ) in
-    redhat-release-server|redhat-release)
+    almalinux-release)
       BASEREPOS=(
-        rhel-9-appstream-rhui-rpms
-        rhel-9-baseos-rhui-rpms
-        rhui-client-config-server-9
+        appstream
+        baseos
+        extras
       )
       ;;
     centos-stream-release)
@@ -131,6 +131,13 @@ function GetDefaultRepos {
         appstream
         baseos
         extras-common
+      )
+      ;;
+    redhat-release-server|redhat-release)
+      BASEREPOS=(
+        rhel-9-appstream-rhui-rpms
+        rhel-9-baseos-rhui-rpms
+        rhui-client-config-server-9
       )
       ;;
     rocky-release)

--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -133,6 +133,13 @@ function GetDefaultRepos {
         extras-common
       )
       ;;
+    oraclelinux-release)
+      BASEREPOS=(
+        ol9_UEKR7
+        ol9_appstream
+        ol9_baseos_latest
+      )
+      ;;
     redhat-release-server|redhat-release)
       BASEREPOS=(
         rhel-9-appstream-rhui-rpms

--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -133,6 +133,13 @@ function GetDefaultRepos {
         extras-common
       )
       ;;
+    rocky-release)
+      BASEREPOS=(
+        appstream
+        baseos
+        extras
+      )
+      ;;
     *)
       echo "Unknown OS. Aborting" >&2
       exit 1

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -174,8 +174,11 @@ function ConfigureCloudInit {
   local CLOUDCFG
 
   CLOUDCFG="${CHROOTMNT}/etc/cloud/cloud.cfg"
-  CLINITUSR=$( grep -E "name: (maintuser|centos|ec2-user|cloud-user)" \
-        "${CLOUDCFG}" | awk '{print $2}')
+  CLINITUSR="$(
+    grep -E "name: (maintuser|centos|ec2-user|cloud-user|almalinux)" \
+      "${CLOUDCFG}" | \
+    awk '{print $2}'
+  )"
 
   # Reset key parms in standard cloud.cfg file
   if [ "${CLINITUSR}" = "" ]


### PR DESCRIPTION
Validated in us-east-1. Added further support for Alma Linux, Rocky Linux and Oracle Linux. Created images for all distros supported by AMIgen9:

~~~bash
$ aws ec2 describe-images \
    --owner self \
    --query 'sort_by(
      Images, &CreationDate
    )[?
      CreationDate >= `2023-12-13`
    ].{ImageId:ImageId,CreationDate:CreationDate,Name:Name}' \
    --output table
-------------------------------------------------------------------------------------------------------------------
|                                                 DescribeImages                                                  |
+--------------------------+------------------------+-------------------------------------------------------------+
|       CreationDate       |        ImageId         |                            Name                             |
+--------------------------+------------------------+-------------------------------------------------------------+
|  2023-12-13T16:49:41.000Z|  ami-00c82c4735af44214 |  spel-minimal-alma-9-hvm-2023.12.1-b01.x86_64.gp3           |
|  2023-12-13T16:50:27.000Z|  ami-057cec947bffc736d |  spel-minimal-centos-9stream-hvm-2023.12.1-b01.x86_64.gp3   |
|  2023-12-13T16:52:23.000Z|  ami-04d0d6d42be1257be |  spel-minimal-rhel-9-hvm-2023.12.1-b01.x86_64.gp3           |
|  2023-12-13T16:53:27.000Z|  ami-0d6ef8cf0a413b52e |  spel-minimal-rocky-9-hvm-2023.12.1-b01.x86_64.gp3          |
|  2023-12-13T17:16:15.000Z|  ami-02e384313ad333a81 |  spel-minimal-ol-9-hvm-2023.12.1-b01.x86_64.gp3             |
+--------------------------+------------------------+-------------------------------------------------------------+
~~~