### PR TITLE
Tweeks to Better-Support Cross-distro Builds

### DIFF
--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -196,8 +196,22 @@ function CarveBare {
 }
 
 function CleanChrootDiskPrtTbl {
+  local HAS_PARTS
   local PART_NUM
   local PDEV
+
+  HAS_PARTS="$(
+    parted -s "${CHROOTDEV}" print | \
+    sed -e '1,/^Number/d' \
+        -e '/^$/d'
+  )"
+
+  # Ensure there's actually partitions to clear
+  if [[ -z ${HAS_PARTS:-} ]]
+  then
+    echo "Disk has no partitions to clear"
+    return
+  fi
 
   # Iteratively nuke partitions from NVMe devices
   if [[ ${CHROOTDEV} == "/dev/nvme"* ]]

--- a/DualMode-GRUBsetup.sh
+++ b/DualMode-GRUBsetup.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -eo pipefail
+set -x
+
+EFI_HOME="$( rpm -ql grub2-common | grep '/EFI/' )"
+GRUB_HOME=/boot/grub2
+
+# Re-Install RPMs as necessary
+if [[ $( rpm --quiet -q grub2-pc )$? -eq 0 ]]
+then
+  dnf -y reinstall grub2-pc
+else
+  dnf -y install grub2-pc
+fi
+
+# Move "${EFI_HOME}/grub.cfg" as necessary
+if [[ -e ${EFI_HOME}/grub.cfg ]]
+then
+  mv "${EFI_HOME}/grub.cfg" /boot/grub2
+fi
+
+# Make our /boot-hosted GRUB2 grub.cfg file
+grub2-mkconfig -o /boot/grub2/grub.cfg
+
+# Nuke grubenv file as necessary
+if [[ -e /boot/grub2/grubenv ]]
+then
+  rm -f /boot/grub2/grubenv
+fi
+
+# Create fresh grubenv file
+grub2-editenv /boot/grub2/grubenv create
+
+# Populate fresh grubenv file:
+#   Use `grub2-editenv` command to list parm/vals already stored in the
+#   "${EFI_HOME}/grubenv"and dupe them into the BIOS-boot GRUB2 env config
+while read -r line
+do
+  key="$( echo "$line" | cut -f1 -d'=' )"
+  value="$( echo "$line" | cut -f2- -d'=' )"
+  grub2-editenv /boot/grub2/grubenv set "${key}"="${value}"
+done <<< "$( grub2-editenv "${EFI_HOME}/grubenv" list )"
+
+if [[ -e ${EFI_HOME}/grubenv ]]
+then
+  rm -f "${EFI_HOME}/grubenv"
+fi
+
+
+BOOT_UUID="$( grub2-probe --target=fs_uuid "${GRUB_HOME}" )"
+GRUB_DIR="$( grub2-mkrelpath "${GRUB_HOME}" )"
+
+# Ensure EFI grub.cfg is correctly populated
+cat << EOF > "${EFI_HOME}/grub.cfg"
+connectefi scsi
+search --no-floppy --fs-uuid --set=dev ${BOOT_UUID}
+set prefix=(\$dev)${GRUB_DIR}
+export \$prefix
+configfile \$prefix/grub.cfg
+EOF
+
+# Clear out stale grub2-efi.cfg file as necessary
+if [[ -e /etc/grub2-efi.cfg ]]
+then
+  rm -f /etc/grub2-efi.cfg
+fi
+
+# Link the BIOS- and EFI-boot GRUB-config files
+ln -s ../boot/grub2/grub.cfg /etc/grub2-efi.cfg
+
+# Calculate the /boot-hosting root-device
+GRUB_TARG="$( df -P /boot/grub2 | awk 'NR>=2 { print $1 }' )"
+
+# Trim off partition-info
+case "${GRUB_TARG}" in
+  /dev/nvme*)
+    GRUB_TARG="${GRUB_TARG//p*/}"
+    ;;
+  /dev/xvd*)
+    GRUB_TARG="${GRUB_TARG::-1}"
+    ;;
+  *)
+    echo "Unsupported disk-type. Aborting..."
+    exit 1
+    ;;
+esac
+
+# Install the /boot/grub2/i386-pc content
+grub2-install --target i386-pc "${GRUB_TARG}"

--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -230,7 +230,17 @@ function PrepChroot {
   fi
 
   # Stage our base RPMs
-  yumdownloader -y --destdir=/tmp "${BASEPKGS[@]}"
+  if [[ -n ${OSREPOS:-} ]]
+  then
+    dnf download \
+      --disablerepo "*" \
+      --enablerepo  "${OSREPOS}" \
+      -y \
+      --destdir /tmp "${BASEPKGS[@]}"
+  else
+    dnf download -y --destdir /tmp "${BASEPKGS[@]}"
+  fi
+
   if [[ ${REPORPMS:-} != '' ]]
   then
     FetchCustomRepos

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -447,6 +447,25 @@ function GrubSetup {
 
 }
 
+function GrubSetup_BIOS {
+  err_exit "Installing helper-script..." NONE
+  install -bDm 0755  "$( dirname "${0}" )/DualMode-GRUBsetup.sh" \
+    "${CHROOTMNT}/root" || err_exit "Failed installing helper-script"
+  err_exit "SUCCESS" NONE
+
+  err_exit "Running helper-script..." NONE
+  chroot "${CHROOTMNT}" /root/DualMode-GRUBsetup.sh || \
+    err_exit "Failed running helper-script..."
+  err_exit "SUCCESS" NONE
+
+  err_exit "Cleaning up helper-script..." NONE
+  rm "${CHROOTMNT}/root/DualMode-GRUBsetup.sh" || \
+    err_exit "Failed removing helper-script..."
+  err_exit "SUCCESS" NONE
+
+}
+
+
 # Configure SELinux
 function SELsetup {
   if [[ -d ${CHROOTMNT}/sys/fs/selinux ]]
@@ -657,6 +676,9 @@ ConfigureCloudInit
 
 # Do GRUB2 setup tasks
 GrubSetup
+
+# Do GRUB2 setup tasks for BIOS-boot compatibility
+GrubSetup_BIOS
 
 # Initialize authselect subsystem
 authselectInit

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -381,9 +381,11 @@ function GrubSetup {
   GRUBCMDLINE="${ROOTTOK} "
   GRUBCMDLINE+="vconsole.keymap=us "
   GRUBCMDLINE+="vconsole.font=latarcyrheb-sun16 "
-  GRUBCMDLINE+="console=tty0 "
+  GRUBCMDLINE+="console=tty1 "
   GRUBCMDLINE+="console=ttyS0,115200n8 "
+  GRUBCMDLINE+="rd.blacklist=nouveau "
   GRUBCMDLINE+="net.ifnames=0 "
+  GRUBCMDLINE+="nvme_core.io_timeout=4294967295 "
   if [[ ${FIPSDISABLE} == "true" ]]
   then
     GRUBCMDLINE+="fips=0"
@@ -396,7 +398,7 @@ function GrubSetup {
     printf 'GRUB_DISTRIBUTOR="CentOS Linux"\n'
     printf 'GRUB_DEFAULT=saved\n'
     printf 'GRUB_DISABLE_SUBMENU=true\n'
-    printf 'GRUB_TERMINAL="serial console"\n'
+    printf 'GRUB_TERMINAL_OUTPUT="console"\n'
     printf 'GRUB_SERIAL_COMMAND="serial --speed=115200"\n'
     printf 'GRUB_CMDLINE_LINUX="%s"\n' "${GRUBCMDLINE}"
     printf 'GRUB_DISABLE_RECOVERY=true\n'

--- a/XdistroSetup.sh
+++ b/XdistroSetup.sh
@@ -10,6 +10,7 @@ PROGNAME=$( basename "$0" )
 PROGDIR="$( dirname "${0}" )"
 RUNDIR="$( dirname "$0" )"
 DEBUG="${DEBUG:-UNDEF}"
+HOME="${HOME:-/root}"
 
 # Import shared error-exit function
 source "${PROGDIR}/err_exit.bashlib"


### PR DESCRIPTION
In order to be able to create EFI-enabled EC2s when vendor-published AMIs don't enable it, it's necessary to bootstrap from an AMI that _is_ EFI-enabled. These updates improve the cross-distro logic already in the project to make them more-easily and more-reliably produce AMIs with the desired attributes.

* Fix base RPM-staging in OS-packages script
* Add 'exit if no partitions' logic to disk-setup script
* Add BIOS-compatibility logic to post-build script
* Try to ensure GRUB-settings support AWS-capturable console-output