### PR TITLE
Ensure all expected GRUB2 kernelopts are present

### DIFF
--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -429,7 +429,7 @@ function GrubSetup {
 
   err_exit "Installing GRUB config-file..." NONE
   chroot "${CHROOTMNT}" /bin/bash -c "/sbin/grub2-mkconfig \
-    > /boot/grub2/grub.cfg" || \
+    -o /boot/grub2/grub.cfg --update-bls-cmdline" || \
     err_exit "Failed to install GRUB config-file"
   err_exit "GRUB config-file installed" NONE
 


### PR DESCRIPTION
Include BLS argument in `/sbin/grub2-mkconfig` invocation to ensure that  `${CHROOTMNT}/etc/default/grub` gets read/processed properly

Closes #26 

Looks it also addresses issue with console output not showing up in AWS.