### PR TITLE
Issue 31

### DIFF
--- a/AWSutils.sh
+++ b/AWSutils.sh
@@ -418,10 +418,6 @@ function InstallCfnBootstrap_systemd {
 
     chroot "${CHROOTMNT}" /usr/bin/systemctl disable "${SVC_NAME}.service" || \
       err_exit "FAILED"
-
-    err_exit "Get rid of SysV-init file... " NONE
-    rm "${CHROOTMNT}/etc/init.d/${SVC_NAME}" || \
-      err_exit "FAILED"
   fi
 
   return

--- a/AWSutils.sh
+++ b/AWSutils.sh
@@ -418,6 +418,10 @@ function InstallCfnBootstrap_systemd {
 
     chroot "${CHROOTMNT}" /usr/bin/systemctl disable "${SVC_NAME}.service" || \
       err_exit "FAILED"
+
+    err_exit "Get rid of SysV-init file... " NONE
+    rm "${CHROOTMNT}/etc/init.d/${SVC_NAME}" || \
+      err_exit "FAILED"
   fi
 
   return

--- a/AWSutils.sh
+++ b/AWSutils.sh
@@ -351,8 +351,8 @@ function InstallCfnBootstrap {
       err_exit "Failed making cfn-hup service executable"
 
     err_exit "Using alternatives to configure cfn-hup symlink and initscript..." NONE
-    chroot "${CHROOTMNT}" alternatives --verbose --install /opt/aws/bin/cfn-hup cfn-hup /usr/local/bin/cfn-hup 1 --initscript cfn-hup || \
-      err_exit "Failed configuring cfn-hup symlink and initscript"
+    chroot "${CHROOTMNT}" alternatives --verbose --install /opt/aws/bin/cfn-hup cfn-hup /usr/local/bin/cfn-hup 1 || \
+      err_exit "Failed configuring cfn-hup symlink"
 
     # Install systemd-supporting content
     InstallCfnBootstrap_systemd


### PR DESCRIPTION
As noted in the [issue-comment](https://github.com/plus3it/amigen9/issues/31#issuecomment-2407956470), the remaining log-spamming comes from SysV-init files laid down by an RPM published by Red Hat. This PR's changes will only address the:

```
[  944.388690] systemd-rc-local-generator[43024]: /etc/rc.d/rc.local is not marked executable, skipping.
[  944.598280] systemd-sysv-generator[43028]: SysV service '/etc/rc.d/init.d/cfn-hup' lacks a native systemd unit file. Automatically generating a unit file for compatibility. Please update package to include a native systemd unit file, in order to make it more safe and robust.
```

Log-spamming.

The log-spamming coming from the `rh-amazon-rhui-client` RPM:
![image](https://github.com/user-attachments/assets/babaa9dc-9476-4e09-b6db-e30e3316e1e4)
Will continue until Red Hat updates and fixes that RPM's services' setups.

This PR Closes #31.