### PR TITLE
Revert "Update DiskSetup.sh"

### DIFF
--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -197,12 +197,18 @@ function CarveBare {
 }
 
 function CleanChrootDiskPrtTbl {
+  local HAS_PARTS
   local PART_NUM
   local PDEV
 
+  HAS_PARTS="$(
+    parted -s "${CHROOTDEV}" print | \
+    sed -e '1,/^Number/d' \
+        -e '/^$/d'
+  )"
 
-  # Exit if there's no VTOC to clear
-  if [[ $( parted -s "${CHROOTDEV}" print > /dev/null 2>&1 )$? -ne 0 ]]
+  # Ensure there's actually partitions to clear
+  if [[ -z ${HAS_PARTS:-} ]]
   then
     echo "Disk has no partitions to clear"
     return


### PR DESCRIPTION
Reverts plus3it/amigen9#37

Change resulted in error during spel builds:

```
    amazon-ebssurrogate.minimal-rhel-9-hvm: Deleting partition /dev/nvme1n1 from /dev/nvme1n1... + parted -sf /dev/nvme1n1 rm /dev/nvme1n1
    amazon-ebssurrogate.minimal-rhel-9-hvm: Error: Partition doesn't exist.
```