### PR TITLE
Work around (new) weirdness in `yum` RPM

### DIFF
--- a/DualMode-GRUBsetup.sh
+++ b/DualMode-GRUBsetup.sh
@@ -84,6 +84,9 @@ case "${GRUB_TARG}" in
   /dev/xvd*)
     GRUB_TARG="${GRUB_TARG::-1}"
     ;;
+  /dev/sd*)
+    GRUB_TARG="${GRUB_TARG::-1}"
+    ;;
   *)
     echo "Unsupported disk-type. Aborting..."
     exit 1

--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -225,6 +225,7 @@ function PrepChroot {
   fi
 
   # Clean out stale RPMs
+  # shellcheck disable=SC2327,SC2328
   if [[ $( stat /tmp/*.rpm > /dev/null 2>&1 )$? -eq 0 ]]
   then
     err_exit "Cleaning out stale RPMs..." NONE
@@ -263,7 +264,7 @@ function PrepChroot {
   if [[ -d ${CHROOTMNT}/etc/yum/pluginconf.d ]]
   then
     echo "Deleting ${CHROOTMNT}/etc/yum/pluginconf.d"
-    rm -rf ${CHROOTMNT}/etc/yum/pluginconf.d
+    rm -rf "${CHROOTMNT}/etc/yum/pluginconf.d"
   fi
 
   # Install dependences for base RPMs

--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -259,6 +259,13 @@ function PrepChroot {
   rpm --force --root "${CHROOTMNT}" -ivh --nodeps --nopre /tmp/*.rpm || \
     err_exit "Failed installing staged RPMs"
 
+  # Work around recent gimpiness in yum RPM
+  if [[ -d ${CHROOTMNT}/etc/yum/pluginconf.d ]]
+  then
+    echo "Deleting ${CHROOTMNT}/etc/yum/pluginconf.d"
+    rm -rf ${CHROOTMNT}/etc/yum/pluginconf.d
+  fi
+
   # Install dependences for base RPMs
   err_exit "Installing base RPM's dependences..." NONE
   yum --disablerepo="*" --enablerepo="${OSREPOS}" \


### PR DESCRIPTION
Closes #57

Recently, doing a `dnf reinstall yum` has started failing due to the previous installation of `yum` having created a `${CHROOTMNT}/etc/yum/pluginconf.d` that the RPM's script-actions doesn't like. This adds a conditional removal of the (now) offending directory.