### PR TITLE
Work around for XFS/GRUB2 Issues Introduced by Amazon with the September-published AMIs

### DIFF
--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -263,9 +263,16 @@ function SetupBootParts {
 
   # Make filesystem for /boot
   err_exit "Creating filesystem on ${CHROOTDEV}${PARTPRE:-}3..." NONE
-  mkfs -t "${FSTYPE}" "${MKFSFORCEOPT}" -L "${LABEL_BOOT}" \
-    "${CHROOTDEV}${PARTPRE:-}3" || \
-    err_exit "Failed creating filesystem"
+  if [[ $( uname -r ) =~ amzn2023 ]]
+  then
+    mkfs -t "${FSTYPE}" "${MKFSFORCEOPT}" -L "${LABEL_BOOT}" \
+      -i nrext64=0 "${CHROOTDEV}${PARTPRE:-}3" || \
+      err_exit "Failed creating filesystem"
+  else
+    mkfs -t "${FSTYPE}" "${MKFSFORCEOPT}" -L "${LABEL_BOOT}" \
+      "${CHROOTDEV}${PARTPRE:-}3" || \
+      err_exit "Failed creating filesystem"
+  fi
 }
 
 


### PR DESCRIPTION
Per AWS Support case 175863457006243:

> The internal team has been able to replicate the issue on their end
> as well and they were also able to find the root cause. The al2023
> XFSProgs package was updated to 6.12. This neabled the experimental
> feature `nrext64` (extended support for large extents) by default.
> This currently cannot be handled by the grub2 package.
>
> Internal team also let me know that they are working on the fix at
> the grub side. However, there is no timeline for when this fix will
> be available. Once the fix is ready, the internal team will release
> the update.
>
> They have also provided the workaround. Please see below:
>
> Customer can disable nrext64 flag explicitly by including it in
> the mkfs.xfs option Command:
>
>   mkfs.xfs -i nrext64=0 <device>

This PR makes the `mkfs` operation for the XFS-formatted `/boot` partition conditional: if bootstrap AMI is al2023-derived, the above `mkfs`-option is activates; all other bootstraps continue with original behavior